### PR TITLE
Free allocated buffer if init_screen() function fails

### DIFF
--- a/toy.c
+++ b/toy.c
@@ -54,6 +54,7 @@ main()
 
     if (init_screen() == 0) {
 	puts("Cannot set video mode: 640x480 @ 16 colors");
+	free(mem);
 	return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
Hello,
The allocated buffer in the `mem` variable isn't being freed if `init_screen(...)` fails. This PR fixes that.